### PR TITLE
Fix a bug in FWFT mode where the rd and wd counts were incorrect

### DIFF
--- a/src/xpm/xpm_fifo/hdl/xpm_fifo_base.vhd
+++ b/src/xpm/xpm_fifo/hdl/xpm_fifo_base.vhd
@@ -1576,7 +1576,7 @@ begin --architecture rtl
         count_down <= '0';
      end if;
      count_en   <= count_up or count_down;
-     count_rst  <= (rd_rst_i or (not (or curr_fwft_state) and not (and next_fwft_state)));
+     count_rst  <= (rd_rst_i or (not (or curr_fwft_state) and not (or next_fwft_state)));
     end process;
     rdpp1_inst0: entity work.xpm_counter_updn 
     generic map(2, 0)


### PR DESCRIPTION
Presumably this is a typo, checking the sv file that was likely used as a base shows the following line:
`assign count_rst  = (rd_rst_i | (~|curr_fwft_state & ~|next_fwft_state));`
which is the intended logic, however the logic below is different.

This was presumably a typo as the fix below seems to be the intended behavior.

Fixing this issue resolves #9 