### PR TITLE
Fix xpm_memory_sdpram component generics

### DIFF
--- a/src/xpm/xpm_VCOMP.vhd
+++ b/src/xpm/xpm_VCOMP.vhd
@@ -73,6 +73,8 @@ component xpm_memory_sdpram
     MEMORY_PRIMITIVE        : string  := "auto"         ;
     CLOCKING_MODE           : string  := "common_clock" ;
     ECC_MODE                : string  := "no_ecc"       ;
+    ECC_TYPE                : string  := "none"         ;
+    ECC_BIT_RANGE           : string  := "7:0"          ;
     MEMORY_INIT_FILE        : string  := "none"         ;
     MEMORY_INIT_PARAM       : string  := ""             ;
     USE_MEM_INIT            : integer := 1              ;
@@ -766,13 +768,13 @@ component xpm_fifo_axif
     s_axi_awlock                : in  std_logic_vector(2-1 downto 0);
     s_axi_awcache               : in  std_logic_vector(4-1 downto 0);
     s_axi_awprot                : in  std_logic_vector(3-1 downto 0);
-    s_axi_awqos                 : in  std_logic_vector(4-1 downto 0); 
+    s_axi_awqos                 : in  std_logic_vector(4-1 downto 0);
     s_axi_awregion              : in  std_logic_vector(4-1 downto 0);
     s_axi_awuser                : in  std_logic_vector(AXI_AWUSER_WIDTH-1 downto 0);
     s_axi_awvalid               : in  std_logic;
     s_axi_awready               : out std_logic;
     s_axi_wdata                 : in  std_logic_vector(AXI_DATA_WIDTH-1 downto 0);
-    s_axi_wstrb                 : in  std_logic_vector(AXI_DATA_WIDTH/8-1 downto 0); 
+    s_axi_wstrb                 : in  std_logic_vector(AXI_DATA_WIDTH/8-1 downto 0);
     s_axi_wlast                 : in  std_logic;
     s_axi_wuser                 : in  std_logic_vector(AXI_WUSER_WIDTH-1 downto 0);
     s_axi_wvalid                : in  std_logic;
@@ -826,7 +828,7 @@ component xpm_fifo_axif
     s_axi_ruser                 : out std_logic_vector(AXI_RUSER_WIDTH-1 downto 0);
     s_axi_rvalid                : out std_logic;
     s_axi_rready                : in  std_logic;
-    m_axi_arid                  : out std_logic_vector(AXI_ID_WIDTH-1 downto 0);       
+    m_axi_arid                  : out std_logic_vector(AXI_ID_WIDTH-1 downto 0);
     m_axi_araddr                : out std_logic_vector(AXI_ADDR_WIDTH-1 downto 0);
     m_axi_arlen                 : out std_logic_vector(AXI_LEN_WIDTH-1 downto 0);
     m_axi_arsize                : out std_logic_vector(3-1 downto 0);
@@ -839,7 +841,7 @@ component xpm_fifo_axif
     m_axi_aruser                : out std_logic_vector(AXI_ARUSER_WIDTH-1 downto 0);
     m_axi_arvalid               : out std_logic;
     m_axi_arready               : in  std_logic;
-    m_axi_rid                   : in  std_logic_vector(AXI_ID_WIDTH-1 downto 0);     
+    m_axi_rid                   : in  std_logic_vector(AXI_ID_WIDTH-1 downto 0);
     m_axi_rdata                 : in  std_logic_vector(AXI_DATA_WIDTH-1 downto 0);
     m_axi_rresp                 : in  std_logic_vector(2-1 downto 0);
     m_axi_rlast                 : in  std_logic;
@@ -908,7 +910,7 @@ component xpm_fifo_axil
     s_axi_awvalid               : in  std_logic;
     s_axi_awready               : out std_logic;
     s_axi_wdata                 : in  std_logic_vector(AXI_DATA_WIDTH-1 downto 0);
-    s_axi_wstrb                 : in  std_logic_vector(AXI_DATA_WIDTH/8-1 downto 0); 
+    s_axi_wstrb                 : in  std_logic_vector(AXI_DATA_WIDTH/8-1 downto 0);
     s_axi_wvalid                : in  std_logic;
     s_axi_wready                : out std_logic;
     s_axi_bresp                 : out std_logic_vector(2-1 downto 0);
@@ -932,11 +934,11 @@ component xpm_fifo_axil
     s_axi_rdata                 : out std_logic_vector(AXI_DATA_WIDTH-1 downto 0);
     s_axi_rresp                 : out std_logic_vector(2-1 downto 0);
     s_axi_rvalid                : out std_logic;
-    s_axi_rready                : in  std_logic;		
+    s_axi_rready                : in  std_logic;
     m_axi_araddr                : out std_logic_vector(AXI_ADDR_WIDTH-1 downto 0);
     m_axi_arprot                : out std_logic_vector(3-1 downto 0);
     m_axi_arvalid               : out std_logic;
-    m_axi_arready               : in  std_logic;   
+    m_axi_arready               : in  std_logic;
     m_axi_rdata                 : in  std_logic_vector(AXI_DATA_WIDTH-1 downto 0);
     m_axi_rresp                 : in  std_logic_vector(2-1 downto 0);
     m_axi_rvalid                : in  std_logic;
@@ -962,5 +964,3 @@ end component;
 
 
 end VCOMPONENTS;
-
-

--- a/src/xpm/xpm_VCOMP.vhd
+++ b/src/xpm/xpm_VCOMP.vhd
@@ -154,7 +154,7 @@ component xpm_memory_tdpram
     SIM_ASSERT_CHK          : integer := 0               ;
     WRITE_PROTECT           : integer := 1               ;
     RAM_DECOMP              : string  := "auto"          ;
-    IGNORE_INIT_SYNTH       : integer := 0							 ;
+    IGNORE_INIT_SYNTH       : integer := 0               ;
 
     -- Port A module generics
     WRITE_DATA_WIDTH_A : integer := 32          ;

--- a/src/xpm/xpm_VCOMP.vhd
+++ b/src/xpm/xpm_VCOMP.vhd
@@ -139,6 +139,8 @@ component xpm_memory_tdpram
     MEMORY_PRIMITIVE        : string  := "auto"         ;
     CLOCKING_MODE           : string  := "common_clock" ;
     ECC_MODE                : string  := "no_ecc"       ;
+    ECC_TYPE                : string  := "none"         ;
+    ECC_BIT_RANGE           : string  := "[7:0]"        ;
     MEMORY_INIT_FILE        : string  := "none"         ;
     MEMORY_INIT_PARAM       : string  := ""             ;
     USE_MEM_INIT            : integer := 1              ;
@@ -151,6 +153,8 @@ component xpm_memory_tdpram
     CASCADE_HEIGHT          : integer := 0               ;
     SIM_ASSERT_CHK          : integer := 0               ;
     WRITE_PROTECT           : integer := 1               ;
+    RAM_DECOMP              : string  := "auto"          ;
+    IGNORE_INIT_SYNTH       : integer := 0							 ;
 
     -- Port A module generics
     WRITE_DATA_WIDTH_A : integer := 32          ;


### PR DESCRIPTION
I use the repo with the the vhdl-ls extension in VSCode. The language server complainted about some missing generics a colleague of mine used in his part of the code. I noticed Vivado (we use 2022.1) added some generics to the component. 
I added the generics to the component according to the instantiation template from Vivado.

VSCode also removed some trailing whitespaces while saving.

