### PR TITLE
add generics to sdpram and tdpram entities [Vivado 2023.2]

### DIFF
--- a/src/xpm/xpm_memory/hdl/xpm_memory_sdpram.vhd
+++ b/src/xpm/xpm_memory/hdl/xpm_memory_sdpram.vhd
@@ -24,6 +24,8 @@ entity xpm_memory_sdpram is
     MEMORY_PRIMITIVE        : string  := "auto"         ;
     CLOCKING_MODE           : string  := "common_clock" ;
     ECC_MODE                : string  := "no_ecc"       ;
+    ECC_TYPE                : string  := "none"         ;
+    ECC_BIT_RANGE           : string  := "7:0"          ;
     MEMORY_INIT_FILE        : string  := "none"         ;
     MEMORY_INIT_PARAM       : string  := ""             ;
     USE_MEM_INIT            : integer := 1              ;

--- a/src/xpm/xpm_memory/hdl/xpm_memory_tdpram.vhd
+++ b/src/xpm/xpm_memory/hdl/xpm_memory_tdpram.vhd
@@ -27,6 +27,8 @@ entity xpm_memory_tdpram is
     MEMORY_PRIMITIVE        : string  := "auto"         ;
     CLOCKING_MODE           : string  := "common_clock" ;
     ECC_MODE                : string  := "no_ecc"       ;
+    ECC_TYPE                : string  := "none"         ;
+    ECC_BIT_RANGE           : string  := "[7:0]"        ;
     MEMORY_INIT_FILE        : string  := "none"         ;
     MEMORY_INIT_PARAM       : string  := ""             ;
     USE_MEM_INIT            : integer := 1              ;
@@ -39,6 +41,8 @@ entity xpm_memory_tdpram is
     CASCADE_HEIGHT          : integer := 0               ;
     SIM_ASSERT_CHK          : integer := 0               ;
     WRITE_PROTECT           : integer := 1               ;
+    RAM_DECOMP              : string  := "auto"          ;
+    IGNORE_INIT_SYNTH       : integer := 0               ;
 
     -- Port A module generics
     WRITE_DATA_WIDTH_A : integer := 32          ;


### PR DESCRIPTION
This PR is a follow up to https://github.com/fransschreuder/xpm_vhdl/pull/13

In the other PR, the  xpm_memory component generics were added to 

- `src/xpm/xpm_VCOMP.vhd` 

which contains the component instantiation.

They were **not** added to 

- `xpm_memory_sdpram.vhd`
- `xpm_memory_tdpram.vhd` 

which contain the respective entity declarations.

I added them here because without this change my VHDL module (originally implemented with Vivado 2023.2) which assigns `xpm_memory_sdpram.vhd` generics `ECC_TYPE` and `ECC_BIT_RANGE` would not compile in a cocotb testbench with GHDL. After adding them to the actual entity declaration in xpm_vhdl it worked.