### PR TITLE
Added generic EN_SIM_ASSERT_ERR to xpm_fifo_axis [Vivado 2024.2]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+compiled_libs/

--- a/README.md
+++ b/README.md
@@ -6,20 +6,34 @@ Xilinx has provided a very convenient library with Vivado called XPM. The librar
 
 The XPM VHDL library needs to be compiled with the VHDL-2008 standard.
 
-## Compilation (GHDL/Vunit)
+## Compilation
 
-In order to compile the library and run the testbench, a script was included.
+### Using GHDL and VUnit
 
-Dependencies:
+A helper script is provided to compile the library and run the testbench.
+
+**Dependencies**
+
 * GHDL
 * GtkWave
 * VUnit
-* Python3
+* Python 3
 
-```
+**Steps:**
+
+```bash
 cd script
 ./run_vunit.py
 ```
+
+### Manual Compilation
+
+To compile the library directly without VUnit, run:
+
+```bash
+./compile_ghdl_xpm_library.sh
+```
+
 
 ## Synthesis
 
@@ -32,4 +46,5 @@ This library was not created by Xilinx, but it should be functionally the same o
 This library has not completely been verified, if you find any bugs or limitations please report using the bug trackers.
 
 Known limitations:
- * ECC mode and bit error injection is not implemented
+ * ECC mode and bit error injection is not implemented.
+ * `EN_SIM_ASSERT_ERR` parameter for `xpm_fifo_axis` is not internally implemented.

--- a/src/xpm/xpm_VCOMP.vhd
+++ b/src/xpm/xpm_VCOMP.vhd
@@ -679,7 +679,8 @@ component xpm_fifo_axis
     PROG_FULL_THRESH         : integer  := 10;
     PROG_EMPTY_THRESH        : integer  := 10;
     SIM_ASSERT_CHK           : integer := 0    ;
-    CDC_SYNC_STAGES          : integer  := 2
+    CDC_SYNC_STAGES          : integer  := 2;
+    EN_SIM_ASSERT_ERR        : string := "warning"  -- Just a placeholder to match xilinx xpm library
   );
   port (
     s_aresetn                      : in  std_logic;

--- a/src/xpm/xpm_fifo/hdl/xpm_fifo_axis.vhd
+++ b/src/xpm/xpm_fifo/hdl/xpm_fifo_axis.vhd
@@ -35,8 +35,9 @@ entity xpm_fifo_axis is
     RD_DATA_COUNT_WIDTH      : integer  := 1;
     PROG_FULL_THRESH         : integer  := 10;
     PROG_EMPTY_THRESH        : integer  := 10;
-    SIM_ASSERT_CHK           : integer := 0    ;
-    CDC_SYNC_STAGES          : integer  := 2
+    SIM_ASSERT_CHK           : integer := 0;
+    CDC_SYNC_STAGES          : integer  := 2;
+    EN_SIM_ASSERT_ERR        : string := "warning"  -- Just a placeholder to match xilinx xpm library
   );
   port (
     s_aresetn                      : in  std_logic;
@@ -75,7 +76,7 @@ end xpm_fifo_axis;
 
 architecture rtl of xpm_fifo_axis is
 
-
+  constant KEEP_GENERIC : string := EN_SIM_ASSERT_ERR;
 
   function clog2(N : natural) return positive is
   begin


### PR DESCRIPTION
Added a new generic `EN_SIM_ASSERT_ERR` to xpm_fifo_axis for compatibility with Vivado 2024.2 and also updated the manual compilation script to add an option to use without Vivado.