### PR TITLE
Implement common clocking mode in xpm_memory_base.

### DIFF
--- a/src/xpm/xpm_memory/hdl/xpm_memory_base.vhd
+++ b/src/xpm/xpm_memory/hdl/xpm_memory_base.vhd
@@ -105,6 +105,8 @@ architecture rtl of xpm_memory_base is
     constant c_num_bytes_a : integer := (WRITE_DATA_WIDTH_A / BYTE_WRITE_WIDTH_A);
     constant c_num_bytes_b : integer := (WRITE_DATA_WIDTH_B / BYTE_WRITE_WIDTH_B);
     
+    signal clk_a, clk_b   : std_logic;
+  
     signal douta_i        : std_logic_vector(READ_DATA_WIDTH_A-1 downto 0) := (others => '0');
     signal doutb_i        : std_logic_vector(READ_DATA_WIDTH_B-1 downto 0) := (others => '0');
   
@@ -286,12 +288,16 @@ begin
     -- "read_first"    1 ;
     -- "no_change"     2 ; 
 
+    -- Common clock uses clka for both ports, independent clocking uses clka for port A and clkb for port B
+  clk_a <= clka;
+  clk_b <= clka when CLOCKING_MODE = 0 else clkb;
+
   gen_readfirst_a : if(WRITE_MODE_A = 1) generate
-    process (clka, rsta)
+    process (clk_a, rsta)
     begin
       if rsta = '1' then
         douta_i <= (others => '0');
-      elsif rising_edge(clka) then
+      elsif rising_edge(clk_a) then
         if ena = '1' then
           douta_i <= ram.Get_A(addra);
           ram.SetBE_A(addra, dina, wea);
@@ -301,11 +307,11 @@ begin
   end generate gen_readfirst_a;
   
   gen_writefirst_a : if(WRITE_MODE_A = 0) generate
-    process (clka, rsta)
+    process (clk_a, rsta)
     begin
       if rsta = '1' then
         douta_i <= (others => '0');
-      elsif rising_edge(clka) then
+      elsif rising_edge(clk_a) then
         if ena = '1' then
           ram.SetBE_A(addra, dina, wea);
           douta_i <= ram.Get_A(addra);
@@ -315,11 +321,11 @@ begin
   end generate gen_writefirst_a;
   
   gen_nochange_a : if(WRITE_MODE_A = 2) generate
-    process (clka, rsta)
+    process (clk_a, rsta)
     begin
       if rsta = '1' then
         douta_i <= (others => '0');
-      elsif rising_edge(clka) then
+      elsif rising_edge(clk_a) then
         if ena = '1' then
           if(wea = (wea'range=> '0')) then
             douta_i <= ram.Get_A(addra);
@@ -333,11 +339,11 @@ begin
   
   
   gen_readfirst_b : if(WRITE_MODE_B = 1) generate
-    process (clkb, rstb)
+    process (clk_b, rstb)
     begin
       if rstb = '1' then
         doutb_i <= (others => '0');
-      elsif rising_edge(clkb) then
+      elsif rising_edge(clk_b) then
         if enb = '1' then
           doutb_i <= ram.Get_B(addrb);
           ram.SetBE_B(addrb, dinb, web);
@@ -347,11 +353,11 @@ begin
   end generate gen_readfirst_b;
   
   gen_writefirst_b : if(WRITE_MODE_B = 0) generate
-    process (clkb, rstb)
+    process (clk_b, rstb)
     begin
       if rstb = '1' then
         doutb_i <= (others => '0');
-      elsif rising_edge(clkb) then
+      elsif rising_edge(clk_b) then
         if enb = '1' then
           ram.SetBE_B(addrb, dinb, web);
           doutb_i <= ram.Get_B(addrb);
@@ -361,11 +367,11 @@ begin
   end generate gen_writefirst_b;
   
   gen_nochange_b : if(WRITE_MODE_B = 2) generate
-    process (clkb, rstb)
+    process (clk_b, rstb)
     begin
       if rstb = '1' then
           doutb_i <= (others => '0');
-      elsif rising_edge(clkb) then
+      elsif rising_edge(clk_b) then
         if enb = '1' then
           if(web = (web'range=> '0')) then
             doutb_i <= ram.Get_B(addrb);
@@ -380,7 +386,7 @@ begin
     output_reg_b(READ_LATENCY_B) <= doutb_i;
   end generate;
   g_latb_2: if READ_LATENCY_B >= 2 generate
-    output_reg_b_proc: process(clkb, rstb)
+    output_reg_b_proc: process(clk_b, rstb)
     begin
         if rstb = '1' then
             for i in 2 to READ_LATENCY_B loop
@@ -390,7 +396,7 @@ begin
                     output_reg_b(i) <= (others => '0');
                 end if;
             end loop;
-        elsif rising_edge(clkb) then
+        elsif rising_edge(clk_b) then
             if regceb = '1' then
                 for i in 2 to READ_LATENCY_B loop
                     if i = 2 then
@@ -410,7 +416,7 @@ begin
   end generate;
   g_lata_2: if READ_LATENCY_A >= 2 generate
   
-    output_reg_a_proc: process(clka, rsta)
+    output_reg_a_proc: process(clk_a, rsta)
     begin
         if rsta = '1' then
             for i in 2 to READ_LATENCY_A loop
@@ -420,7 +426,7 @@ begin
                     output_reg_a(i) <= (others => '0');
                 end if;
             end loop;
-        elsif rising_edge(clka) then
+        elsif rising_edge(clk_a) then
             if regcea = '1' then
                 for i in 2 to READ_LATENCY_A loop
                     if i = 2 then


### PR DESCRIPTION
The `CLOCKING_MODE` generic is set to the values I expect in each of the `xpm_memory` files, but is unused by `xpm_memory_base`. I expect the clock for both ports to use `clka` when `CLOCKING_MODE` is set to `0` (`common_clock` mode), and ports A and B to use `clka` and `clkb`, respectively when `CLOCKING_MODE` is set to `1` (`independent_clock` mode), but only the latter mode has been implemented. 

I had a go at changing this in my commit, but unsure if this is the best way of masking out `clkb` when `CLOCKING_MODE = 1`. It could also be achieved by having branching `generate` statements depending on the value of `CLOCKING_MODE`, changing the sensitivity list of all port B processes to use `clka` instead, but this is a lot of code duplication. 