### PR TITLE
Implement deterministic cross-port read-first behavior in xpm_memory_base

### DIFF
--- a/script/run_vunit.py
+++ b/script/run_vunit.py
@@ -13,6 +13,7 @@ xpm_lib.add_source_files(join(root, '../src/xpm/xpm_fifo/hdl', '*.vhd'))
 
 work_lib = prj.add_library('work_lib')
 work_lib.add_source_files(join(root, '../src/xpm/xpm_fifo/simulation', '*.vhd'))
+work_lib.add_source_files(join(root, '../src/xpm/xpm_memory/simulation', '*.vhd'))
 work_lib.set_sim_option("disable_ieee_warnings", True)
 work_lib.set_sim_option("ghdl.sim_flags", ["--max-stack-alloc=0"])
 

--- a/src/xpm/xpm_memory/hdl/xpm_memory_base.vhd
+++ b/src/xpm/xpm_memory/hdl/xpm_memory_base.vhd
@@ -280,63 +280,68 @@ architecture rtl of xpm_memory_base is
   
   signal output_reg_a: slv_rwa_array;
   signal output_reg_b: slv_rwb_array;
-    
+
+  -- One read/modify/write "cycle" for both ports, shared by the common-clock and
+  -- independent-clock processes below. ev_a / ev_b indicate that this call is an
+  -- active (enabled, out-of-reset) rising edge for the respective port; the caller
+  -- computes them from its own clock(s). Both reads are sampled from the current
+  -- memory contents BEFORE either write is applied, so a simultaneous same-address
+  -- access on the opposite port reads the old contents (read-first), matching
+  -- block-RAM hardware (which has no cross-port write-to-read forwarding). Each port
+  -- still honors its own write mode with respect to its own write.
+  procedure mem_cycle(ev_a, ev_b : in boolean;
+                      signal q_a : out std_logic_vector(READ_DATA_WIDTH_A - 1 downto 0);
+                      signal q_b : out std_logic_vector(READ_DATA_WIDTH_B - 1 downto 0)) is
+    variable rd_a : std_logic_vector(READ_DATA_WIDTH_A - 1 downto 0);
+    variable rd_b : std_logic_vector(READ_DATA_WIDTH_B - 1 downto 0);
+  begin
+    -- Phase 1: sample both reads from the pre-write memory contents.
+    if ev_a then rd_a := ram.Get_A(addra); end if;
+    if ev_b then rd_b := ram.Get_B(addrb); end if;
+
+    -- Phase 2: apply both writes (a write with all byte-enables low is a no-op).
+    if ev_a then ram.SetBE_A(addra, dina, wea); end if;
+    if ev_b then ram.SetBE_B(addrb, dinb, web); end if;
+
+    -- Phase 3: drive each port's output register according to its write mode.
+    if rsta = '1' then
+      q_a <= (others => '0');
+    elsif ev_a then
+      if WRITE_MODE_A = 0 then                       -- write_first: own just-written data
+        q_a <= ram.Get_A(addra);
+      elsif WRITE_MODE_A = 1 then                    -- read_first: pre-write data
+        q_a <= rd_a;
+      elsif wea = (wea'range => '0') then            -- no_change: update only when not writing
+        q_a <= rd_a;
+      end if;
+    end if;
+
+    if rstb = '1' then
+      q_b <= (others => '0');
+    elsif ev_b then
+      if WRITE_MODE_B = 0 then
+        q_b <= ram.Get_B(addrb);
+      elsif WRITE_MODE_B = 1 then
+        q_b <= rd_b;
+      elsif web = (web'range => '0') then
+        q_b <= rd_b;
+      end if;
+    end if;
+  end procedure;
+
 begin
 
     -- "write_first"   0;
     -- "read_first"    1 ;
     -- "no_change"     2 ; 
 
-  -- Common-clock mode: both ports run on clka. To reproduce block-RAM
-  -- read-during-write behaviour deterministically we evaluate BOTH ports' reads
-  -- from the current memory contents BEFORE applying EITHER write, so a
-  -- simultaneous same-address access on the opposite port reads the old contents
-  -- (read-first) regardless of the order the simulator would otherwise evaluate
-  -- the two ports, matching hardware (which has no cross-port write-to-read
-  -- forwarding path). Each port still honours its own write mode w.r.t. its own
-  -- write. (The independent-clock block below is identical except port B is
-  -- clocked by clkb.)
+  -- Common-clock mode: both ports run on clka.
   g_common_clock: if(CLOCKING_MODE = 0) generate
     mem_proc : process (clka, rsta, rstb)
-      variable rd_a : std_logic_vector(READ_DATA_WIDTH_A - 1 downto 0);
-      variable rd_b : std_logic_vector(READ_DATA_WIDTH_B - 1 downto 0);
-      variable ev_a, ev_b : boolean;
     begin
-      ev_a := (rsta = '0') and rising_edge(clka) and (ena = '1');
-      ev_b := (rstb = '0') and rising_edge(clka) and (enb = '1');
-
-      -- Phase 1: sample both reads from the pre-write memory contents.
-      if ev_a then rd_a := ram.Get_A(addra); end if;
-      if ev_b then rd_b := ram.Get_B(addrb); end if;
-
-      -- Phase 2: apply both writes (a write with all byte-enables low is a no-op).
-      if ev_a then ram.SetBE_A(addra, dina, wea); end if;
-      if ev_b then ram.SetBE_B(addrb, dinb, web); end if;
-
-      -- Phase 3: drive each port's output register according to its write mode.
-      if rsta = '1' then
-        douta_i <= (others => '0');
-      elsif ev_a then
-        if WRITE_MODE_A = 0 then                       -- write_first: own just-written data
-          douta_i <= ram.Get_A(addra);
-        elsif WRITE_MODE_A = 1 then                    -- read_first: pre-write data
-          douta_i <= rd_a;
-        elsif wea = (wea'range => '0') then            -- no_change: update only when not writing
-          douta_i <= rd_a;
-        end if;
-      end if;
-
-      if rstb = '1' then
-        doutb_i <= (others => '0');
-      elsif ev_b then
-        if WRITE_MODE_B = 0 then
-          doutb_i <= ram.Get_B(addrb);
-        elsif WRITE_MODE_B = 1 then
-          doutb_i <= rd_b;
-        elsif web = (web'range => '0') then
-          doutb_i <= rd_b;
-        end if;
-      end if;
+      mem_cycle(ev_a => (rsta = '0') and rising_edge(clka) and (ena = '1'),
+                ev_b => (rstb = '0') and rising_edge(clka) and (enb = '1'),
+                q_a => douta_i, q_b => doutb_i);
     end process;
 
     g_latb_1: if READ_LATENCY_B < 2 generate
@@ -367,52 +372,13 @@ begin
       end process;
     end generate;
 
-  -- Independent-clock mode: identical to the common-clock block above, except
-  -- port B is clocked by clkb. Each port acts on its own clock edge; if the
-  -- two clocks happen to align, both reads are still taken before either write
-  -- (read-first), which is benign for the otherwise-undefined cross-clock
-  -- collision case.
+  -- Independent-clock mode: identical to above except port B clocked by clkb.
   else generate
     mem_proc : process (clka, clkb, rsta, rstb)
-      variable rd_a : std_logic_vector(READ_DATA_WIDTH_A - 1 downto 0);
-      variable rd_b : std_logic_vector(READ_DATA_WIDTH_B - 1 downto 0);
-      variable ev_a, ev_b : boolean;
     begin
-      ev_a := (rsta = '0') and rising_edge(clka) and (ena = '1');
-      ev_b := (rstb = '0') and rising_edge(clkb) and (enb = '1');
-
-      -- Phase 1: sample both reads from the pre-write memory contents.
-      if ev_a then rd_a := ram.Get_A(addra); end if;
-      if ev_b then rd_b := ram.Get_B(addrb); end if;
-
-      -- Phase 2: apply both writes (a write with all byte-enables low is a no-op).
-      if ev_a then ram.SetBE_A(addra, dina, wea); end if;
-      if ev_b then ram.SetBE_B(addrb, dinb, web); end if;
-
-      -- Phase 3: drive each port's output register according to its write mode.
-      if rsta = '1' then
-        douta_i <= (others => '0');
-      elsif ev_a then
-        if WRITE_MODE_A = 0 then                       -- write_first: own just-written data
-          douta_i <= ram.Get_A(addra);
-        elsif WRITE_MODE_A = 1 then                    -- read_first: pre-write data
-          douta_i <= rd_a;
-        elsif wea = (wea'range => '0') then            -- no_change: update only when not writing
-          douta_i <= rd_a;
-        end if;
-      end if;
-
-      if rstb = '1' then
-        doutb_i <= (others => '0');
-      elsif ev_b then
-        if WRITE_MODE_B = 0 then
-          doutb_i <= ram.Get_B(addrb);
-        elsif WRITE_MODE_B = 1 then
-          doutb_i <= rd_b;
-        elsif web = (web'range => '0') then
-          doutb_i <= rd_b;
-        end if;
-      end if;
+      mem_cycle(ev_a => (rsta = '0') and rising_edge(clka) and (ena = '1'),
+                ev_b => (rstb = '0') and rising_edge(clkb) and (enb = '1'),
+                q_a => douta_i, q_b => doutb_i);
     end process;
     g_latb_1: if READ_LATENCY_B < 2 generate
       output_reg_b(READ_LATENCY_B) <= doutb_i;

--- a/src/xpm/xpm_memory/hdl/xpm_memory_base.vhd
+++ b/src/xpm/xpm_memory/hdl/xpm_memory_base.vhd
@@ -287,96 +287,58 @@ begin
     -- "read_first"    1 ;
     -- "no_change"     2 ; 
 
-  gen_readfirst_a : if(WRITE_MODE_A = 1) generate
-    process (clka, rsta)
+  -- Common-clock mode: both ports run on clka. To reproduce block-RAM
+  -- read-during-write behaviour deterministically we evaluate BOTH ports' reads
+  -- from the current memory contents BEFORE applying EITHER write, so a
+  -- simultaneous same-address access on the opposite port reads the old contents
+  -- (read-first) regardless of the order the simulator would otherwise evaluate
+  -- the two ports, matching hardware (which has no cross-port write-to-read
+  -- forwarding path). Each port still honours its own write mode w.r.t. its own
+  -- write. (The independent-clock block below is identical except port B is
+  -- clocked by clkb.)
+  g_common_clock: if(CLOCKING_MODE = 0) generate
+    mem_proc : process (clka, rsta, rstb)
+      variable rd_a : std_logic_vector(READ_DATA_WIDTH_A - 1 downto 0);
+      variable rd_b : std_logic_vector(READ_DATA_WIDTH_B - 1 downto 0);
+      variable ev_a, ev_b : boolean;
     begin
-      if rsta = '1' then
-        douta_i <= (others => '0');
-      elsif rising_edge(clka) then
-        if ena = '1' then
-          douta_i <= ram.Get_A(addra);
-          ram.SetBE_A(addra, dina, wea);
-        end if;
-      end if;
-    end process;
-  end generate gen_readfirst_a;
-  
-  gen_writefirst_a : if(WRITE_MODE_A = 0) generate
-    process (clka, rsta)
-    begin
-      if rsta = '1' then
-        douta_i <= (others => '0');
-      elsif rising_edge(clka) then
-        if ena = '1' then
-          ram.SetBE_A(addra, dina, wea);
-          douta_i <= ram.Get_A(addra);
-        end if;
-      end if;
-    end process;
-  end generate gen_writefirst_a;
-  
-  gen_nochange_a : if(WRITE_MODE_A = 2) generate
-    process (clka, rsta)
-    begin
-      if rsta = '1' then
-        douta_i <= (others => '0');
-      elsif rising_edge(clka) then
-        if ena = '1' then
-          if(wea = (wea'range=> '0')) then
-            douta_i <= ram.Get_A(addra);
-          else
-            ram.SetBE_A(addra, dina, wea);
-          end if;
-        end if;
-      end if;
-    end process;
-  end generate gen_nochange_a;
-  
-  g_common_clock: if CLOCKING_MODE = 0 generate -- use clka
-    gen_readfirst_b : if(WRITE_MODE_B = 1) generate
-      process (clka, rstb)
-      begin
-        if rstb = '1' then
-          doutb_i <= (others => '0');
-        elsif rising_edge(clka) then
-          if enb = '1' then
-            doutb_i <= ram.Get_B(addrb);
-            ram.SetBE_B(addrb, dinb, web);
-          end if;
-        end if;
-      end process;
-    end generate gen_readfirst_b;
+      ev_a := (rsta = '0') and rising_edge(clka) and (ena = '1');
+      ev_b := (rstb = '0') and rising_edge(clka) and (enb = '1');
 
-    gen_writefirst_b : if(WRITE_MODE_B = 0) generate
-      process (clka, rstb)
-      begin
-        if rstb = '1' then
-          doutb_i <= (others => '0');
-        elsif rising_edge(clka) then
-          if enb = '1' then
-            ram.SetBE_B(addrb, dinb, web);
-            doutb_i <= ram.Get_B(addrb);
-          end if;
-        end if;
-      end process;
-    end generate gen_writefirst_b;
+      -- Phase 1: sample both reads from the pre-write memory contents.
+      if ev_a then rd_a := ram.Get_A(addra); end if;
+      if ev_b then rd_b := ram.Get_B(addrb); end if;
 
-    gen_nochange_b : if(WRITE_MODE_B = 2) generate
-      process (clka, rstb)
-      begin
-        if rstb = '1' then
-            doutb_i <= (others => '0');
-        elsif rising_edge(clka) then
-          if enb = '1' then
-            if(web = (web'range=> '0')) then
-              doutb_i <= ram.Get_B(addrb);
-            else
-              ram.SetBE_B(addrb, dinb, web);
-            end if;
-          end if;
+      -- Phase 2: apply both writes (a write with all byte-enables low is a no-op).
+      if ev_a then ram.SetBE_A(addra, dina, wea); end if;
+      if ev_b then ram.SetBE_B(addrb, dinb, web); end if;
+
+      -- Phase 3: drive each port's output register according to its write mode.
+      if rsta = '1' then
+        douta_i <= (others => '0');
+      elsif ev_a then
+        if WRITE_MODE_A = 0 then                       -- write_first: own just-written data
+          douta_i <= ram.Get_A(addra);
+        elsif WRITE_MODE_A = 1 then                    -- read_first: pre-write data
+          douta_i <= rd_a;
+        elsif wea = (wea'range => '0') then            -- no_change: update only when not writing
+          douta_i <= rd_a;
         end if;
-      end process;
-    end generate gen_nochange_b;
+      end if;
+
+      if rstb = '1' then
+        doutb_i <= (others => '0');
+      elsif ev_b then
+        if WRITE_MODE_B = 0 then
+          doutb_i <= ram.Get_B(addrb);
+        elsif WRITE_MODE_B = 1 then
+          doutb_i <= rd_b;
+        elsif web = (web'range => '0') then
+          doutb_i <= rd_b;
+        end if;
+      end if;
+    end process;
+
     g_latb_1: if READ_LATENCY_B < 2 generate
       output_reg_b(READ_LATENCY_B) <= doutb_i;
     end generate;
@@ -404,51 +366,54 @@ begin
           end if;
       end process;
     end generate;
-  else generate --use clkb
-    gen_readfirst_b : if(WRITE_MODE_B = 1) generate
-      process (clkb, rstb)
-      begin
-        if rstb = '1' then
-          doutb_i <= (others => '0');
-        elsif rising_edge(clkb) then
-          if enb = '1' then
-            doutb_i <= ram.Get_B(addrb);
-            ram.SetBE_B(addrb, dinb, web);
-          end if;
-        end if;
-      end process;
-    end generate gen_readfirst_b;
 
-    gen_writefirst_b : if(WRITE_MODE_B = 0) generate
-      process (clkb, rstb)
-      begin
-        if rstb = '1' then
-          doutb_i <= (others => '0');
-        elsif rising_edge(clkb) then
-          if enb = '1' then
-            ram.SetBE_B(addrb, dinb, web);
-            doutb_i <= ram.Get_B(addrb);
-          end if;
-        end if;
-      end process;
-    end generate gen_writefirst_b;
+  -- Independent-clock mode: identical to the common-clock block above, except
+  -- port B is clocked by clkb. Each port acts on its own clock edge; if the
+  -- two clocks happen to align, both reads are still taken before either write
+  -- (read-first), which is benign for the otherwise-undefined cross-clock
+  -- collision case.
+  else generate
+    mem_proc : process (clka, clkb, rsta, rstb)
+      variable rd_a : std_logic_vector(READ_DATA_WIDTH_A - 1 downto 0);
+      variable rd_b : std_logic_vector(READ_DATA_WIDTH_B - 1 downto 0);
+      variable ev_a, ev_b : boolean;
+    begin
+      ev_a := (rsta = '0') and rising_edge(clka) and (ena = '1');
+      ev_b := (rstb = '0') and rising_edge(clkb) and (enb = '1');
 
-    gen_nochange_b : if(WRITE_MODE_B = 2) generate
-      process (clkb, rstb)
-      begin
-        if rstb = '1' then
-            doutb_i <= (others => '0');
-        elsif rising_edge(clkb) then
-          if enb = '1' then
-            if(web = (web'range=> '0')) then
-              doutb_i <= ram.Get_B(addrb);
-            else
-              ram.SetBE_B(addrb, dinb, web);
-            end if;
-          end if;
+      -- Phase 1: sample both reads from the pre-write memory contents.
+      if ev_a then rd_a := ram.Get_A(addra); end if;
+      if ev_b then rd_b := ram.Get_B(addrb); end if;
+
+      -- Phase 2: apply both writes (a write with all byte-enables low is a no-op).
+      if ev_a then ram.SetBE_A(addra, dina, wea); end if;
+      if ev_b then ram.SetBE_B(addrb, dinb, web); end if;
+
+      -- Phase 3: drive each port's output register according to its write mode.
+      if rsta = '1' then
+        douta_i <= (others => '0');
+      elsif ev_a then
+        if WRITE_MODE_A = 0 then                       -- write_first: own just-written data
+          douta_i <= ram.Get_A(addra);
+        elsif WRITE_MODE_A = 1 then                    -- read_first: pre-write data
+          douta_i <= rd_a;
+        elsif wea = (wea'range => '0') then            -- no_change: update only when not writing
+          douta_i <= rd_a;
         end if;
-      end process;
-    end generate gen_nochange_b;
+      end if;
+
+      if rstb = '1' then
+        doutb_i <= (others => '0');
+      elsif ev_b then
+        if WRITE_MODE_B = 0 then
+          doutb_i <= ram.Get_B(addrb);
+        elsif WRITE_MODE_B = 1 then
+          doutb_i <= rd_b;
+        elsif web = (web'range => '0') then
+          doutb_i <= rd_b;
+        end if;
+      end if;
+    end process;
     g_latb_1: if READ_LATENCY_B < 2 generate
       output_reg_b(READ_LATENCY_B) <= doutb_i;
     end generate;

--- a/src/xpm/xpm_memory/simulation/xpm_memory_base_cc_tb.vhd
+++ b/src/xpm/xpm_memory/simulation/xpm_memory_base_cc_tb.vhd
@@ -1,0 +1,119 @@
+--! Copyright [2020] [Frans Schreuder]
+--!
+--!   Licensed under the Apache License, Version 2.0 (the "License");
+--!   you may not use this file except in compliance with the License.
+--!   You may obtain a copy of the License at
+--!
+--!       http://www.apache.org/licenses/LICENSE-2.0
+--!
+--!   Unless required by applicable law or agreed to in writing, software
+--!   distributed under the License is distributed on an "AS IS" BASIS,
+--!   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--!   See the License for the specific language governing permissions and
+--!   limitations under the License.
+-- Module Name: xpm_memory_base_cc_tb.vhd
+-- Description:
+--   Memory-level regression test for the common-clocking-mode change in
+--   xpm_memory_base (PR #19 / PR #20). Instantiates xpm_memory_base directly in
+--   common-clock, simple-dual-port, read_first, READ_LATENCY=1 configuration.
+--   Writes a ramp to consecutive addresses on port A and reads them back on port
+--   B, then checks the read-back sequence is the intact ramp.
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+library vunit_lib;
+context vunit_lib.vunit_context;
+library xpm;
+
+entity xpm_memory_base_cc_tb is
+  generic (runner_cfg : string := runner_cfg_default);
+end entity;
+
+architecture tb of xpm_memory_base_cc_tb is
+  constant DW    : integer := 32;          -- data width
+  constant AW    : integer := 12;          -- address width
+  constant DEPTH : integer := 4096;
+  constant N     : integer := 64;          -- words written/read back
+  constant BASE  : integer := 256;          -- ramp offset so the read-port reset
+                                            -- value (0) can't masquerade as data
+  constant MARGIN: integer := 4;           -- extra capture cycles for latency
+
+  signal clk  : std_logic := '0';
+  signal wea  : std_logic_vector(DW/8-1 downto 0) := (others => '0');
+  signal addra, addrb : std_logic_vector(AW-1 downto 0) := (others => '0');
+  signal dina : std_logic_vector(DW-1 downto 0) := (others => '0');
+  signal doutb: std_logic_vector(DW-1 downto 0);
+
+  type int_array is array (natural range <>) of integer;
+begin
+
+  clk <= not clk after 1 ns;
+
+  dut: entity xpm.xpm_memory_base
+    generic map (
+      MEMORY_SIZE        => DEPTH*DW,
+      MEMORY_PRIMITIVE   => 1,
+      CLOCKING_MODE      => 0,            -- common_clock
+      WRITE_DATA_WIDTH_A => DW, READ_DATA_WIDTH_A => DW, BYTE_WRITE_WIDTH_A => 8,
+      ADDR_WIDTH_A       => AW, READ_LATENCY_A => 1, WRITE_MODE_A => 1,
+      WRITE_DATA_WIDTH_B => DW, READ_DATA_WIDTH_B => DW, BYTE_WRITE_WIDTH_B => 8,
+      ADDR_WIDTH_B       => AW, READ_LATENCY_B => 1, WRITE_MODE_B => 1
+    )
+    port map (
+      sleep => '0',
+      clka => clk, rsta => '0', ena => '1', regcea => '1',
+      wea => wea, addra => addra, dina => dina,
+      injectsbiterra => '0', injectdbiterra => '0',
+      douta => open, sbiterra => open, dbiterra => open,
+      clkb => clk, rstb => '0', enb => '1', regceb => '1',
+      web => (others => '0'), addrb => addrb, dinb => (others => '0'),
+      injectsbiterrb => '0', injectdbiterrb => '0',
+      doutb => doutb, sbiterrb => open, dbiterrb => open
+    );
+
+  main: process
+    variable capv    : int_array(0 to N+MARGIN-1) := (others => -1);
+    variable aligned : boolean;
+  begin
+    test_runner_setup(runner, runner_cfg);
+
+    -- write a ramp: address a holds value a + BASE
+    wea <= (others => '1');
+    for a in 0 to N-1 loop
+      addra <= std_logic_vector(to_unsigned(a, AW));
+      dina  <= std_logic_vector(to_unsigned(a + BASE, DW));
+      wait until rising_edge(clk);
+    end loop;
+    wea <= (others => '0');
+    addra <= (others => '0');
+
+    -- read back addresses 0..N-1 in order, capturing dout each cycle
+    for c in 0 to N+MARGIN-1 loop
+      if c < N then
+        addrb <= std_logic_vector(to_unsigned(c, AW));
+      end if;
+      wait until rising_edge(clk);
+      capv(c) := to_integer(unsigned(doutb));
+    end loop;
+
+    -- The intact ramp BASE..BASE+N-1 must appear as a contiguous in-order run,
+    -- regardless of absolute read latency. A delta-skew shift reads one address
+    -- ahead, so value BASE is never returned and this run is absent.
+    aligned := false;
+    for off in 0 to MARGIN loop
+      aligned := true;
+      for k in 0 to N-1 loop
+        if capv(off+k) /= k + BASE then
+          aligned := false;
+        end if;
+      end loop;
+      exit when aligned;
+    end loop;
+
+    check(aligned, "common-clock read-back is not the intact ramp BASE..BASE+N-1 (delta-skew shift)");
+    test_runner_cleanup(runner);
+    wait;
+  end process;
+
+  test_runner_watchdog(runner, 100 us);
+end architecture;

--- a/src/xpm/xpm_memory/simulation/xpm_memory_sdpram_tb.vhd
+++ b/src/xpm/xpm_memory/simulation/xpm_memory_sdpram_tb.vhd
@@ -1,0 +1,145 @@
+--! Copyright [2020] [Frans Schreuder]
+--!
+--!   Licensed under the Apache License, Version 2.0 (the "License");
+--!   you may not use this file except in compliance with the License.
+--!   You may obtain a copy of the License at
+--!
+--!       http://www.apache.org/licenses/LICENSE-2.0
+--!
+--!   Unless required by applicable law or agreed to in writing, software
+--!   distributed under the License is distributed on an "AS IS" BASIS,
+--!   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--!   See the License for the specific language governing permissions and
+--!   limitations under the License.
+-- Module Name: xpm_memory_base_sdpram_tb.vhd
+-- Description:
+-- Regression test for cross-port read-during-write in a Simple Dual Port RAM.
+-- With a common clock and the write port in READ_FIRST mode, UG573 guarantees
+-- that a simultaneous read and write to the same address returns the *previously
+-- stored* data on the read port (block RAM has no cross-port write-to-read
+-- forwarding path). This testbench writes a location, then reads it while writing
+-- a new value to it in the same cycle, and checks that the old value is returned.
+library vunit_lib;
+context vunit_lib.vunit_context;
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+library xpm;
+
+entity xpm_memory_sdpram_tb is
+  generic(runner_cfg : string := runner_cfg_default);
+end xpm_memory_sdpram_tb;
+
+architecture tb of xpm_memory_sdpram_tb is
+
+  constant DW    : integer := 32;
+  constant AW    : integer := 5;
+  constant DEPTH : integer := 2 ** AW;
+
+  constant OLD_VALUE : std_logic_vector(DW - 1 downto 0) := x"0000AAAA";
+  constant NEW_VALUE : std_logic_vector(DW - 1 downto 0) := x"0000BBBB";
+  constant ADDR      : std_logic_vector(AW - 1 downto 0) := std_logic_vector(to_unsigned(7, AW));
+
+  signal clk   : std_logic := '0';
+  signal wea   : std_logic_vector(0 downto 0) := "0";
+  signal addra : std_logic_vector(AW - 1 downto 0) := (others => '0');
+  signal dina  : std_logic_vector(DW - 1 downto 0) := (others => '0');
+  signal addrb : std_logic_vector(AW - 1 downto 0) := (others => '0');
+  signal doutb : std_logic_vector(DW - 1 downto 0);
+
+  constant CLK_PERIOD : time := 10 ns;
+  signal running : boolean := true;
+
+begin
+
+  clkgen : process
+  begin
+    while running loop
+      clk <= '0';
+      wait for CLK_PERIOD / 2;
+      clk <= '1';
+      wait for CLK_PERIOD / 2;
+    end loop;
+    wait;
+  end process;
+
+  dut : entity xpm.xpm_memory_sdpram
+    generic map (
+      MEMORY_PRIMITIVE   => "block",
+      MEMORY_SIZE        => DEPTH * DW,
+      CLOCKING_MODE      => "common_clock",
+      WRITE_DATA_WIDTH_A => DW,
+      BYTE_WRITE_WIDTH_A => DW,
+      ADDR_WIDTH_A       => AW,
+      READ_DATA_WIDTH_B  => DW,
+      ADDR_WIDTH_B       => AW,
+      READ_LATENCY_B     => 1,
+      WRITE_MODE_B       => "read_first"
+    )
+    port map (
+      sleep          => '0',
+      clka           => clk,
+      ena            => '1',
+      wea            => wea,
+      addra          => addra,
+      dina           => dina,
+      injectsbiterra => '0',
+      injectdbiterra => '0',
+      clkb           => clk,
+      rstb           => '0',
+      enb            => '1',
+      regceb         => '1',
+      addrb          => addrb,
+      doutb          => doutb,
+      sbiterrb       => open,
+      dbiterrb       => open
+    );
+
+  main : process
+  begin
+    test_runner_setup(runner, runner_cfg);
+
+    -- Inputs are driven on the falling edge so they are stable at the rising edge
+    -- that acts on them; doutb (read latency 1) is then sampled on the next falling
+    -- edge. Each step below spans exactly one rising edge.
+    wea <= "0";
+    wait until falling_edge(clk);
+
+    -- Write OLD_VALUE to ADDR.
+    addra <= ADDR;
+    dina  <= OLD_VALUE;
+    wea   <= "1";
+    wait until falling_edge(clk);         -- rising edge here writes OLD_VALUE
+    wea   <= "0";
+    dina  <= (others => '0');
+
+    -- Plain read-back of ADDR.
+    addrb <= ADDR;
+    wait until falling_edge(clk);         -- rising edge registers the read
+    check_equal(doutb, OLD_VALUE, "plain read-back of written location");
+
+    -- Cross-port read-during-write: write NEW_VALUE to ADDR while reading ADDR.
+    addra <= ADDR;
+    dina  <= NEW_VALUE;
+    wea   <= "1";
+    addrb <= ADDR;
+    wait until falling_edge(clk);         -- rising edge: write NEW_VALUE, read ADDR
+    wea   <= "0";
+    dina  <= (others => '0');
+    -- READ_FIRST: the read must see the OLD contents, not the value being written.
+    check_equal(doutb, OLD_VALUE,
+      "cross-port read-during-write must return OLD data (read_first)");
+
+    -- The write must still have taken effect.
+    addrb <= ADDR;
+    wait until falling_edge(clk);         -- rising edge registers the read
+    check_equal(doutb, NEW_VALUE, "write during the collision cycle took effect");
+
+    running <= false;
+    test_runner_cleanup(runner);
+    wait;
+  end process;
+
+  test_runner_watchdog(runner, 1 ms);
+
+end tb;


### PR DESCRIPTION
This branch includes three commits:

1. Adds a regression test for the bug introduced in #19 (and fixed in #20).

2. Xilinx guarantees that for a block RAM with a common clock and the write port in `READ_FIRST` mode, a simultaneous read and write of the same address deterministically returns the old data on the read port (UG573, "Address Collision"). The `xpm_memory_base` entity currently doesn't implement this – the two ports are in separate processes which share the memory, so the read data depends on undefined process-evaluation order and can incorrectly return the just-written data. This commit ensures that both reads are evaluated before either write, to ensure deterministic read-first behavior.

3. Pure refactoring, no behavior change. This commit tries to reduce code duplication by factoring out the read-modify-write cycle into a procedure that is called by both the common-clock and independent-clock cases. I consider this **optional** – I don't mind if you prefer the previous version and don't want to merge this one.

cc @fransschreuder 